### PR TITLE
Fixed a redirect_to bug

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,7 +22,7 @@ class SessionsController < ApplicationController
       user.location = user_hash['location']
       user.save!
       session[:github_login] = user.github_login
-      redirect_target = :edit_profile
+      redirect_target = edit_profile_path(user.profile.id)
     end
 
     redirect_to redirect_target


### PR DESCRIPTION
`redirect_to :edit_profile` led to an invalid route matching.
Additionally the redirect to the edit page should involve profile._id.
