### PR TITLE
Fix twitter link typo

### DIFF
--- a/app/views/home/about.html.haml
+++ b/app/views/home/about.html.haml
@@ -9,7 +9,7 @@
     %a{href: "http://www.lonestarrubyconf.com/"} Lone Star Ruby Conf 2011
     to help developers who would like to pair together find each other.
     She told a few people about her idea; some of them mentioned this
-    %a{href: "http://twtitter.com/elight"} Evan Light
+    %a{href: "http://twitter.com/elight"} Evan Light
     guy who had been remote pairing with people a lot at the time.
     Nola found Evan and they immediately started pairing on the beginning of Ruby Pair.
 


### PR DESCRIPTION
The about page has a twitter link to "twtitter.com" which is sending people to tweetadder.com. Made me think your rubypair site was a scam the first time I clicked it :)
