### PR TITLE
Twitter Normalization

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,10 +19,14 @@ class User
 
   fulltext_search_in :name, :github_login, :interests, :location
 
-  validates_format_of :twitter,
-    on: :update,
-    with: /^\w+$/,
-    message: "if present must not start with a '@'"
+  # This Normalizes twitter handles - strips and matches them
+  def twitter=(handle)
+    if handle.strip =~ /^@(\w+)$/
+      super($1)
+    else
+      super handle.strip
+    end
+  end
 
   def self.tag_cloud(size = 20)
     interest_histogram

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,20 @@
 require 'test_helper'
 
 describe User do
+  let (:user) { Factory.build(:user) }
+
+  describe "twitter handle" do
+    it "strips a prefixed @-symbol" do
+      user.twitter = "@Lenary"
+      user.twitter.should == "Lenary"
+    end
+
+    it "copes with no prefixed @-symbol" do
+      user.twitter = "Lenary"
+      user.twitter.should == "Lenary"
+    end
+  end
+
   describe "#interest_histogram" do
     before do
       User.create(interests: "foo, bar, blech")


### PR DESCRIPTION
People are complaining of rubypair not liking the @ symbol in twitter handles.

rather than raise a validation error, i think we should just strip the @ symbol off on entry.
