### PR TITLE
add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+---
+rvm: 1.9.2
+notifications:
+  disabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@
 rvm: 1.9.2
 notifications:
   disabled: true
+script: "bundle exec rspec spec"


### PR DESCRIPTION
This should get rubypair testing on travis. if you go to travis-ci.org , sign in and then enable it from your profile, then it should start building, but i was having issues enabling from the travis switches...

Anyway, that's about it. it will run everything sensible for the tests.
