### PR TITLE
updated Gemfile to include working compass branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :assets do
   gem 'sass-rails', "3.1.0"
   gem 'coffee-rails', "3.1.0"
   gem 'uglifier'
-  gem 'compass', :git => 'https://github.com/chriseppstein/compass.git', :branch => 'rails31'
+  gem 'compass', '~> 0.12.alpha'
   gem 'compass-960-plugin'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,3 @@
-GIT
-  remote: https://github.com/chriseppstein/compass.git
-  revision: 22e2458b77519e8eb8463170c1a1fe4bab105f3e
-  branch: rails31
-  specs:
-    compass (0.12.0.alpha.0.22e2458)
-      chunky_png (~> 1.2)
-      fssm (>= 0.2.7)
-      sass (~> 3.1)
-
 GEM
   remote: http://rubygems.org/
   specs:
@@ -57,7 +47,7 @@ GEM
       xpath (~> 0.1.4)
     childprocess (0.2.2)
       ffi (~> 1.0.6)
-    chunky_png (1.2.1)
+    chunky_png (1.2.5)
     coderay (0.9.8)
     coffee-rails (3.1.0)
       coffee-script (>= 2.2.0)
@@ -67,6 +57,10 @@ GEM
       execjs
     coffee-script-source (1.1.2)
     columnize (0.3.4)
+    compass (0.12.alpha.0)
+      chunky_png (~> 1.2)
+      fssm (>= 0.2.7)
+      sass (~> 3.1)
     compass-960-plugin (0.10.4)
       compass (>= 0.10.0)
     database_cleaner (0.6.7)
@@ -262,7 +256,7 @@ DEPENDENCIES
   bson_ext
   capybara
   coffee-rails (= 3.1.0)
-  compass!
+  compass (~> 0.12.alpha)
   compass-960-plugin
   database_cleaner
   factory_girl_rails


### PR DESCRIPTION
Just forked the project and when I tried to 'bundle install' I had issues with getting the rails31 branch of compass to install. Looks like there's a version on RubyGems that works (0.12.alpha).
