### PR TITLE
Fixed typo in about page

### DIFF
--- a/app/views/home/about.html.haml
+++ b/app/views/home/about.html.haml
@@ -30,7 +30,7 @@
     In a nutshell, we're about helping kindred developer spirits find one another.
 
   %p
-    For now, Ruby Pair is a seachable directory of developers who are looking to pair, in-person or remotely,
+    For now, Ruby Pair is a searchable directory of developers who are looking to pair, in-person or remotely,
     on topics that they've expressed an interest in through their profile.  Longer term, we're planning on
     adding recommendation features to more actively help developers find people nearby them, for
     in-person pairing, and with similar interests.


### PR DESCRIPTION
Seachable => Searchable
